### PR TITLE
Row value signal for rows, skip header titles

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -86,6 +86,9 @@ pub(crate) struct TableDataField {
     pub(crate) skip: bool,
 
     #[darling(default)]
+    pub(crate) skip_header: bool,
+
+    #[darling(default)]
     pub(crate) key: bool,
 
     #[darling(default)]

--- a/src/table.rs
+++ b/src/table.rs
@@ -599,7 +599,9 @@ impl ToTokens for TableComponentDeriveInput {
                 continue;
             }
 
-            let title = if let Some(ref t) = f.title {
+            let title = if f.skip_header {
+                "".to_string()
+            } else if let Some(ref t) = f.title {
                 t.clone()
             } else {
                 name.to_string().to_title_case()
@@ -829,6 +831,7 @@ impl ToTokens for TableComponentDeriveInput {
                                                         index=i
                                                         selected=selected_signal
                                                         on_click=on_row_select
+                                                        row_value=item_signal
                                                     >
                                                         #(#cells)*
                                                     </#row_renderer>


### PR DESCRIPTION
Adding a `item_signal` to the Row renderer so that the whole row value is accessible when rendering. Great for creating editing links, etc