### PR TITLE
Remove unneccery special handeling of types and some adjustments

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use darling::util::IdentString;
 use darling::{ast, util};
-use darling::{FromDeriveInput, FromField, FromMeta};
+use darling::{FromDeriveInput, FromField};
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(
@@ -39,7 +41,7 @@ pub(crate) struct TableRowField {
     pub(crate) renderer: Option<IdentString>,
 
     #[darling(default)]
-    pub(crate) format: Format,
+    pub(crate) format: HashMap<syn::Ident, syn::Lit>,
 
     #[darling(default)]
     pub(crate) class: Option<String>,
@@ -99,9 +101,3 @@ impl TableRowField {
     }
 }
 
-#[derive(Default, FromMeta, Debug)]
-#[darling(default)]
-pub(crate) struct Format {
-    pub(crate) string: Option<String>,
-    pub(crate) precision: Option<i64>,
-}

--- a/src/table_row.rs
+++ b/src/table_row.rs
@@ -37,7 +37,7 @@ fn get_default_render_for_inner_type(
     let format_props = get_format_props_for_field(field, type_ident);
     match type_ident.to_string().as_str() {
         _ => quote! {
-            <leptos_struct_table::DefaultTableCellRenderer options={#format_props} #value_prop #class_prop #index_prop on_change=|_| {}/>
+            <leptos_struct_table::DefaultTableCellRenderer options=#format_props #value_prop #class_prop #index_prop on_change=|_| {}/>
         },
     }
 }
@@ -144,24 +144,14 @@ fn get_default_renderer_for_type(
 }
 
 fn get_format_props_for_field(field: &TableRowField, ty: &Ident) -> TokenStream2 {
-    // TODO: this needs to be able to iterate through all field format attributes and set them
-    let precision = if let Some(p) = &field.format.precision {
-        quote! {o.precision = Some((#p as usize));}
-    } else {
-        quote! {}
-    };
-
-    let format_string = if let Some(f) = &field.format.string {
-        quote! {o.format_string = Some(#f.to_string());}
-    } else {
-        quote! {}
-    };
+    let values : Vec<_> = field.format.iter().map(|(ident, value)|  {
+        quote! {o.#ident = Some(#value.into());}
+    }).collect();
 
     quote! {
         {
             let mut o = <#ty as CellValue>::RenderOptions::default();
-            #precision
-            #format_string
+            #(#values)*
             o
       }
     }

--- a/src/table_row.rs
+++ b/src/table_row.rs
@@ -150,7 +150,7 @@ fn get_format_props_for_field(field: &TableRowField, ty: &Ident) -> TokenStream2
 
     quote! {
         {
-            let mut o = <#ty as CellValue>::RenderOptions::default();
+            let mut o = <#ty as ::leptos_struct_table::CellValue>::RenderOptions::default();
             #(#values)*
             o
       }


### PR DESCRIPTION
This attempts to remove some magic coded into the macro, we only then provide a single default cell renderer

this is intended to work with changes to the main non-macro repo and attempts to pipe the rendering options into the CellValue trait render function and moves the special rendering of types into the main repo. 