### PR TITLE
generate valid code for updated leptos-struct-table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos-struct-table-macro"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 authors = ["Marc-Stefan Cassola"]
 description = "Macros for the leptos-struct-table crate."

--- a/src/models.rs
+++ b/src/models.rs
@@ -42,6 +42,9 @@ pub(crate) struct TableRowField {
     pub(crate) ty: syn::Type,
 
     #[darling(default)]
+    pub(crate) marker: Option<syn::Ident>,
+
+    #[darling(default)]
     pub(crate) renderer: Option<IdentString>,
 
     #[darling(default)]

--- a/src/table_row.rs
+++ b/src/table_row.rs
@@ -99,10 +99,19 @@ fn get_default_option_renderer(
                         leptos::view! {
                             <leptos::control_flow::Show
                                 when={
-                                    let value = value.clone();
-                                    move || value.is_some()
+                                    let value = value.is_some();
+                                    move || value
                                 }
-                                fallback=move || leptos::view!{<leptos_struct_table::DefaultTableCellRenderer<#inner_type_ident, _, #marker> value=#none_value.to_string() options={()} #class_prop #index_prop on_change=|_| {}/>}
+                                fallback=move || {
+                                    use leptos_struct_table::DefaultMarker;
+                                    leptos::view! {
+                                        <leptos_struct_table::DefaultTableCellRenderer<String, _, DefaultMarker>
+                                            value=#none_value.clone()
+                                            options={()}
+                                            #class_prop #index_prop on_change=|_| {}
+                                        />
+                                    }
+                                }
                             >
                                 #inner_renderer
                             </leptos::control_flow::Show>

--- a/src/table_row.rs
+++ b/src/table_row.rs
@@ -103,7 +103,7 @@ fn get_default_option_renderer(
                                     move || value
                                 }
                                 fallback=move || {
-                                    use leptos_struct_table::DefaultMarker;
+                                    type DefaultMarker = ();
                                     leptos::view! {
                                         <leptos_struct_table::DefaultTableCellRenderer<String, _, DefaultMarker>
                                             value=#none_value.clone()
@@ -167,7 +167,7 @@ fn get_format_props_for_field(field: &TableRowField, ty: &syn::Type) -> TokenStr
 
     quote! {
         {
-            use leptos_struct_table::DefaultMarker;
+            type DefaultMarker = ();
             let mut o = <#ty as ::leptos_struct_table::CellValue<#marker>>::RenderOptions::default();
             #(#values)*
             o
@@ -575,7 +575,7 @@ impl ToTokens for TableRowDeriveInput {
 
                 fn render_row(self, index: usize, on_change: leptos_struct_table::EventHandler<leptos_struct_table::ChangeEvent<Self>>) -> impl leptos::IntoView {
                     use leptos_struct_table::TableClassesProvider;
-                    use leptos_struct_table::DefaultMarker;
+                    type DefaultMarker = ();
 
                     let class_provider = Self::ClassesProvider::new();
                     let row = self.clone();

--- a/src/table_row.rs
+++ b/src/table_row.rs
@@ -75,10 +75,6 @@ fn get_default_option_renderer(
 
         return match get_inner_type(last_segment, "Option") {
             Ok(inner_type_ident) => {
-                let marker = field.marker.as_ref().map_or_else(
-                    || get_default_cell_value_marker(inner_type_ident),
-                    |marker| quote! { #marker },
-                );
                 let value_prop = quote! {
                     value=value.clone().expect("not None")
                 };
@@ -218,11 +214,11 @@ fn get_default_cell_value_marker(ty: &syn::Type) -> TokenStream2 {
                 "NonZeroI128" => quote! { NonZeroI128 },
                 "NonZeroIsize" => quote! { NonZeroIsize },
                 "NonZeroU8" => quote! { NonZeroU8 },
-                "NonZeroU16" => quote! {NonZeroU16 },
-                "NonZeroU32" => quote! {NonZeroU32 },
-                "NonZeroU64" => quote! {NonZeroU64 },
+                "NonZeroU16" => quote! { NonZeroU16 },
+                "NonZeroU32" => quote! { NonZeroU32 },
+                "NonZeroU64" => quote! { NonZeroU64 },
                 "NonZeroU128" => quote! { NonZeroU128 },
-                "NonZeroUsize" => quote! {NonZeroUsize },
+                "NonZeroUsize" => quote! { NonZeroUsize },
                 "NaiveDate" => quote! { NaiveDate },
                 "NaiveDateTime" => quote! { NaiveDateTime },
                 "NaiveTime" => quote! { NaiveTime },


### PR DESCRIPTION
The current `#[derive(TableRow)]` macro generates code not compatible with `leptos-struct-table` from `leptos-0.7` branch. This PR fixes it.