### PR TITLE
i18n scope support

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -4,6 +4,7 @@ use darling::util::IdentString;
 use darling::{ast, util, FromMeta};
 use darling::{FromDeriveInput, FromField};
 use quote::ToTokens;
+use syn::punctuated::Punctuated;
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(
@@ -85,6 +86,8 @@ pub(crate) struct TableRowField {
 pub(crate) struct I18nStructOptions {
     #[darling(default)]
     pub(crate) path: Option<syn::Path>,
+    #[darling(default)]
+    pub(crate) scope: Option<Punctuated<syn::Ident, syn::Token![.]>>,
 }
 
 #[derive(Debug, FromMeta)]


### PR DESCRIPTION
It's very convinient to have a separate scope for table (or for some component), but the `#[derive(TableRow)]` macro now generates code without the ability to set an i18n scope, so you have to write a lot of `#[table(i18n(key = "table.scope.field"))]` directives. This PR adds a `#[table(i18n(scope = "table.scope"))]` attribute.

```rust
#[derive(TableRow)]
#[table(i18n(scope = "components.students.tables"))]
pub struct Student {
  pub first_name: String,
  pub last_name: String,
  pub birthday: NaiveDate,
}
```

And locale can be like this:
```json
{
  "components": {
    "students": {
      "tables": {
        "first_name": "First name",
        "last_name": "Last name",
        "birthday": "Birthday"
      }
    }
  }
}
```