### PR TITLE
Support for generic Column indexes, and enum creation

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -31,7 +31,7 @@ pub(crate) struct TableRowDeriveInput {
     pub(crate) impl_vec_data_provider: bool,
 
     #[darling(default)]
-    pub(crate) column_index_type: Option<syn::Type>,
+    pub(crate) column_index_type: ColumnIndexType,
 
     #[darling(default)]
     pub(crate) row_type: Option<syn::Type>,
@@ -42,6 +42,7 @@ pub(crate) struct TableRowDeriveInput {
 
 /// How to fill in the generic column type.
 #[derive(Debug, FromMeta, Default)]
+#[darling(rename_all = "lowercase")]
 pub(crate) enum ColumnIndexType {
     /// 0-based index based on struct field positions.
     #[default]

--- a/src/models.rs
+++ b/src/models.rs
@@ -30,10 +30,23 @@ pub(crate) struct TableRowDeriveInput {
     pub(crate) impl_vec_data_provider: bool,
 
     #[darling(default)]
+    pub(crate) column_index_type: Option<syn::Type>,
+
+    #[darling(default)]
     pub(crate) row_type: Option<syn::Type>,
 
     #[darling(default)]
     pub(crate) i18n: Option<I18nStructOptions>,
+}
+
+/// How to fill in the generic column type.
+#[derive(Debug, FromMeta, Default)]
+pub(crate) enum ColumnIndexType {
+    /// 0-based index based on struct field positions.
+    #[default]
+    Usize,
+    /// Generated enum, variants based on struct field names
+    Enum,
 }
 
 #[derive(Debug, FromField)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,6 +14,7 @@ use syn::punctuated::Punctuated;
 )]
 pub(crate) struct TableRowDeriveInput {
     pub(crate) ident: syn::Ident,
+    pub(crate) vis: syn::Visibility,
     pub(crate) data: ast::Data<util::Ignored, TableRowField>,
     pub(crate) generics: syn::Generics,
 

--- a/src/table_row.rs
+++ b/src/table_row.rs
@@ -492,23 +492,6 @@ impl ToTokens for TableRowDeriveInput {
         // List of Column => "name",
         let mut col_name_match_arms = vec![];
 
-        // User provided type converted to an enum with supported types.
-        let column_index_type = column_index_type
-            .as_ref()
-            .map_or(ColumnIndexType::Usize, |t| match t {
-                Type::Path(token_stream) => match token_stream.path.get_ident() {
-                    Some(ident) => {
-                        if *ident == "usize" {
-                            ColumnIndexType::Usize
-                        } else {
-                            ColumnIndexType::Enum
-                        }
-                    }
-                    None => ColumnIndexType::Usize,
-                },
-                _ => ColumnIndexType::Usize,
-            });
-
         // Accumulates the enum variants during the fields loop
         let mut enum_tokens: Option<_> = if matches!(column_index_type, ColumnIndexType::Enum) {
             Some(quote! {})


### PR DESCRIPTION
This change adds an option `column_index_type` to switch the current default usize column indexes to a generated enum.
- Omitting this annotation tells the code to fill in usize into the generic, essentially keeping all previous behaviour.
- Providing this option with a string != "usize" causes an enum to be generated and used.

(I dislike this current config type, I wanted to use an enum first but this crate can't export that).

This pr serves as a progress tracker currently.